### PR TITLE
Add smarter config file handling, etc.

### DIFF
--- a/oo-install/.gitignore
+++ b/oo-install/.gitignore
@@ -1,0 +1,1 @@
+package/

--- a/oo-install/src/ooinstall/ansible.cfg
+++ b/oo-install/src/ooinstall/ansible.cfg
@@ -1,1 +1,25 @@
-annie conf
+# config file for ansible -- http://ansible.com/
+# ==============================================
+
+# This config file provides examples for running
+# the OpenShift playbooks with the provided
+# inventory scripts. Only global defaults are
+# left uncommented
+
+[defaults]
+# Add the roles directory to the roles path
+roles_path = roles/
+
+# Set the log_path
+log_path = /tmp/ansible.log
+
+forks = 10
+host_key_checking = False
+nocows = 1
+# Need to handle:
+# inventory - derive from OO_ANSIBLE_DIRECTORY env var
+# callback_plugins - derive from pkg_resource.resource_filename
+# private_key_file - prompt if missing
+# remote_tmp - set if provided by user (cli)
+# ssh_args - set if provided by user (cli)
+# control_path

--- a/oo-install/src/ooinstall/ansible_plugins/facts_callback.py
+++ b/oo-install/src/ooinstall/ansible_plugins/facts_callback.py
@@ -1,0 +1,76 @@
+import os
+import yaml
+from tempfile import mkstemp
+
+class CallbackModule(object):
+    """
+    """
+
+    def __init__(self):
+        ######################
+        # This is ugly stoopid. This should be updated in the following ways:
+        # 1) it should output host data to predictable files, e.g. $OO_ANSIBLE_DIRECTORY/host_data/hostname.yml
+        # 2) it should only output the host data looked for (e.g. there should be far fewer .writes below
+        # 3) it should probably only be used for the openshift_facts.yml playbook, so maybe there's some way to check a variable that's set when that playbook is run?
+        self.outfile, self.outfile_name = mkstemp()
+        print 'outfile_name = {}'.format(self.outfile_name)
+
+    def on_any(self, *args, **kwargs):
+        pass
+
+    def runner_on_failed(self, host, res, ignore_errors=False):
+        os.write(self.outfile, ('RUNNER_ON_FAILED ' + host + ' ' + yaml.safe_dump(res)))
+
+    def runner_on_ok(self, host, res):
+        os.write(self.outfile, ('RUNNER_ON_OK ' + host + ' ' + yaml.safe_dump(res)))
+
+    def runner_on_skipped(self, host, item=None):
+        os.write(self.outfile, ('RUNNER_ON_SKIPPED ' + host + ' ...'))
+
+    def runner_on_unreachable(self, host, res):
+        os.write(self.outfile, ('RUNNER_UNREACHABLE ' + host + ' ' + yaml.safe_dump(res)))
+
+    def runner_on_no_hosts(self):
+        pass
+
+    def runner_on_async_poll(self, host, res):
+        pass
+
+    def runner_on_async_ok(self, host, res):
+        pass
+
+    def runner_on_async_failed(self, host, res):
+        os.write(self.outfile, ('RUNNER_SYNC_FAILED ' + host + ' ' + yaml.safe_dump(res)))
+
+    def playbook_on_start(self):
+        pass
+
+    def playbook_on_notify(self, host, handler):
+        pass
+
+    def playbook_on_no_hosts_matched(self):
+        pass
+
+    def playbook_on_no_hosts_remaining(self):
+        pass
+
+    def playbook_on_task_start(self, name, is_conditional):
+        pass
+
+    def playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
+        pass
+
+    def playbook_on_setup(self):
+        pass
+
+    def playbook_on_import_for_host(self, host, imported_file):
+        os.write(self.outfile, ('PLAYBOOK_ON_IMPORTED ' + host + ' ' + yaml.safe_dump(res)))
+
+    def playbook_on_not_import_for_host(self, host, missing_file):
+        os.write(self.outfile, ('PLAYBOOK_ON_NOTIMPORTED ' + host + ' ' + yaml.safe_dump(res)))
+
+    def playbook_on_play_start(self, name):
+        pass
+
+    def playbook_on_stats(self, stats):
+        pass

--- a/oo-install/src/ooinstall/install_transactions.py
+++ b/oo-install/src/ooinstall/install_transactions.py
@@ -6,7 +6,7 @@ def set_config(cfg):
 
 def default_facts(hosts):
     global CFG
-    ansible_directory = CFG.settings['ansible_directory']
+    ansible_directory = CFG.ansible_directory
     base_inventory_path = '{}/base_inventory'.format(ansible_directory)
     os_facts_path = '{}/playbooks/byo/openshift_facts.yml'.format(ansible_directory)
     base_inventory = open(base_inventory_path, 'w')

--- a/oo-install/src/ooinstall/oo_config.py
+++ b/oo-install/src/ooinstall/oo_config.py
@@ -1,6 +1,16 @@
 import os
 import yaml
-from pkg_resources import resource_string
+from pkg_resources import resource_string, resource_filename
+
+PERSIST_SETTINGS=[
+    'Description',
+    'Name',
+    'Subscription',
+    'Vendor',
+    'Version',
+    'hosts',
+    'ansible_config',
+    ]
 
 class OOConfigFileError(Exception):
     """The provided config file path can't be read/written
@@ -8,17 +18,12 @@ class OOConfigFileError(Exception):
     pass
 
 class OOConfig(object):
-
-    # ansible_directory = ''
-    # hosts = []
     settings = {}
     new_config = True
-    # default_dir = os.environ['HOME'] + '/.openshift/'
     default_dir = os.path.normpath(
         os.environ.get('XDG_CONFIG_HOME',
                        os.environ['HOME'] + '/.config/') + '/openshift/')
     default_file = '/installer.cfg.yml'
-    config_template = resource_string(__name__, 'installer.cfg.template.yml')
 
     def __init__(self, config_path):
         if config_path:
@@ -26,17 +31,27 @@ class OOConfig(object):
         else:
             self.config_path = os.path.normpath(self.default_dir +
                                                 self.default_file)
-        print 'self.config_path: {}'.format(self.config_path)
-        if os.path.exists(self.config_path):
-            self.read_config()
-        else:
-            self.install_default()
-            self.read_config(is_new = True)
+        self.read_config()
+        self.set_defaults()
+
+    def set_defaults(self):
+        if not 'ansible_config' in self.settings:
+            self.settings['ansible_config'] = resource_filename(__name__, 'ansible.cfg')
+        # clean up any empty sets
+        for setting in self.settings.keys():
+            if not self.settings[setting]:
+                self.settings.pop(setting)
 
     def read_config(self, is_new = False):
         try:
-            cfgfile = open(self.config_path, 'r')
-            self.settings = yaml.safe_load(cfgfile.read())
+            new_settings = None
+            if os.path.exists(self.config_path):
+                cfgfile = open(self.config_path, 'r')
+                new_settings = yaml.safe_load(cfgfile.read())
+            if new_settings:
+                self.settings = new_settings
+            else:
+                self.install_default()
         except IOError, ferr:
             raise OOConfigFileError('Cannot open config file "{}": {}'.format(ferr.filename, ferr.strerror))
         except yaml.scanner.ScannerError:
@@ -48,16 +63,25 @@ class OOConfig(object):
         out_file.write(self.yaml())
         out_file.close()
 
+    def persist_settings(self):
+        p_settings = {}
+        for setting in PERSIST_SETTINGS:
+            if setting in self.settings and self.settings[setting]:
+                p_settings[setting] = self.settings[setting]
+        return p_settings
+
     def yaml(self):
-        return yaml.dump(self.settings)
+        return yaml.safe_dump(self.persist_settings())
 
     def __str__(self):
         return self.yaml()
 
     def install_default(self):
+        config_template = resource_string(__name__, 'installer.cfg.template.yml')
         cfg_dir, cfg_file = os.path.split(self.config_path)
         if not os.path.exists(cfg_dir):
             os.makedirs(cfg_dir)
         out_file = open(self.config_path, 'w')
-        out_file.write(self.config_template)
+        out_file.write(config_template)
+        self.settings = yaml.safe_load(config_template)
         out_file.close()


### PR DESCRIPTION
This adds smarter config file saving and reading.

Values which should ride with the config settings, but shouldn't be
saved, are now filtered prior to saving.

Unattended mode is settable with a flag. New options need to check this
before going into prompt-the-user mode.

The Ansible config file can be specified but isn't used yet.
- certain ansible config options need to be derived and saved to the
  actual config location
- the config needs to be copied to one of these places:
  - ANSIBLE_CONFIG (an environment variable)
  - ansible.cfg (in the current directory)
  - .ansible.cfg (in the home directory)
  - /etc/ansible/ansible.cfg

Other bits and pieces.
